### PR TITLE
Allow dropdown to keep open when clicking on bypassed element

### DIFF
--- a/projects/better-item-toolbar/src/lib/toolbar-template-item-with-dropdown/item-dropdown/item-dropdown-overlay-builder.ts
+++ b/projects/better-item-toolbar/src/lib/toolbar-template-item-with-dropdown/item-dropdown/item-dropdown-overlay-builder.ts
@@ -104,7 +104,12 @@ export class ItemDropdownOverlayBuilder<T, C> {
     this._documentClickPath$.pipe(
       withLatestFrom(dropdownOpen$),
       filter(([eventPath, isOpen]) => {
-        return isOpen && !eventPath.includes(overlayRef.overlayElement) && !eventPath.includes(overlayOriginEl);
+        const dropdownOpen = isOpen && !eventPath.includes(overlayRef.overlayElement) && !eventPath.includes(overlayOriginEl);
+        if (this._config.dropdownBypassElement) {
+          return dropdownOpen && !eventPath.includes(this._config.dropdownBypassElement);
+        } else {
+          return dropdownOpen;
+        }
       })
     ).subscribe(() => {
       overlayRef.detach();
@@ -189,5 +194,5 @@ export interface ItemOverlayBuilderConfig {
   offsetY?: number;
   openOnCreate?: boolean;
   emitAvailableHeightOnResize?: boolean;
+  dropdownBypassElement?: HTMLElement;
 }
-


### PR DESCRIPTION
In our case, we need this to keep dropdown open when user clicks side panel to edit time range picker.